### PR TITLE
修改了个人中心获取头像和用户名的方式

### DIFF
--- a/src/controllers/personalPage.go
+++ b/src/controllers/personalPage.go
@@ -3,8 +3,6 @@ package controllers
 import (
 	"Kcoin-Golang/src/models"
 	_ "Kcoin-Golang/src/models"
-	"encoding/json"
-	"fmt"
 
 	"github.com/astaxie/beego"
 )
@@ -23,20 +21,14 @@ func (c *PersonalPageController) Get() {
 	//		"headShotUrl": "../static/img/tx2.png"
 	//	}
 	//}`
-	status:=c.Ctx.GetCookie("status")
-	{
-		c.Ctx.SetCookie("lastUri",c.Ctx.Request.RequestURI)
-		if status =="0"||status ==""{
-			defer c.Redirect("/login.html",302)
-		}
+	status := c.Ctx.GetCookie("status")
+	c.Ctx.SetCookie("lastUri", c.Ctx.Request.RequestURI)
+	if status == "0" || status == "" {
+		defer c.Redirect("/login.html", 302)
 	}
-	userName := c.Ctx.GetCookie("userName")
-	user := models.UserInfo{Data:&models.UserData{}}//user中存放着json解析后获得的数据。
-	jsonBuf , _ := models.GetUserInfo(userName)
-	errorCode := json.Unmarshal([]byte(jsonBuf), &user)//将jsonBuf的数据解析，然后赋值给user，如果出错会返回对应的errorCode
-	if errorCode != nil {//出错了，panic
-		fmt.Println("you r in personalPage controller ,there is ia bug ,and the information is : ", errorCode.Error())
-	}
+	user := models.UserInfo{Data: &models.UserData{}} //user中存放着json解析后获得的数据。
+	user.Data.UserName = c.Ctx.GetCookie("userName")
+	user.Data.HeadShotUrl = c.Ctx.GetCookie("headShotUrl")
 	c.Data["user"] = user
-	c.TplName = "personalPage.html"//该controller对应的页面
+	c.TplName = "personalPage.html" //该controller对应的页面
 }

--- a/src/controllers/personalProjects.go
+++ b/src/controllers/personalProjects.go
@@ -163,7 +163,6 @@ func (c *PersonalProjectsController) Get() {
 	//}
 	//}`
 	name := c.Ctx.GetCookie("userName")
-	userBuf, _ := models.GetUserInfo(name)
 	projectBuf, _ := models.GetGithubRepos(name)
 
 	status := c.Ctx.GetCookie("status")
@@ -173,15 +172,14 @@ func (c *PersonalProjectsController) Get() {
 		defer c.Redirect("/login.html", 302)
 	}
 
-	user := models.UserInfo{Data: &models.UserData{}}
+	user := models.UserInfo{Data: &models.UserData{}} //user中存放着json解析后获得的数据。
+	user.Data.UserName = c.Ctx.GetCookie("userName")
+	user.Data.HeadShotUrl = c.Ctx.GetCookie("headShotUrl")
+
 	var projects models.ProjectInfo
-	errorCode := json.Unmarshal([]byte(userBuf), &user)
-	errorCode2 := json.Unmarshal([]byte(projectBuf), &projects)
+	errorCode := json.Unmarshal([]byte(projectBuf), &projects)
 
 	if errorCode != nil {
-		fmt.Println("Oops, there is an error:( please keep debugging.", errorCode.Error())
-	}
-	if errorCode2 != nil {
 		fmt.Println("Oops, there is an error:( please keep debugging.", errorCode.Error())
 	}
 


### PR DESCRIPTION
原先是从数据库中获取，但数据库中并没有url这一项，导致个人中心一直显示不出头像；而且用户头像经常会变更，也不应该存在数据库中，所以修改为从cookies中获取用户名和头像url。