### PR TITLE
修改了首页平台管理的跳转，在平台管理页面加入了返回首页的跳转

### DIFF
--- a/src/static/css/platformAdmin.css
+++ b/src/static/css/platformAdmin.css
@@ -18,6 +18,22 @@ a:link,a:visited,a:hover,a:active
     background-color: #333333;
 }
 
+.topNavLogo{
+    float: left;
+    width: 60px;
+    height: 60px;
+    margin-top: 5px;
+    margin-left: 5px;
+    margin-right: 10px;
+}
+
+.topNavName{
+    float: left;
+    line-height: 70px;
+    font-size: 28px;
+    color: aliceblue;
+}
+
 .navigation {
     position: relative;
     height: 160px;

--- a/src/views/homePage.tpl
+++ b/src/views/homePage.tpl
@@ -18,7 +18,7 @@
 
 
 			{{if .isPlatformAdmin}}
-				<a class="head-bt" href="./projectfunding">平台管理</a>
+				<a class="head-bt" href="/platformInformation">平台管理</a>
 			{{else}}
 				<!--不是平台管理员，不显示平台管理按钮-->
 			{{end}}

--- a/src/views/platformAdminTopNav.html
+++ b/src/views/platformAdminTopNav.html
@@ -7,6 +7,10 @@
 </head>
 <body>
     <div class="head">
+        <a href="/homepage">
+            <img class="topNavLogo" src="/static/img/kcoin-logo-blue.png"/>
+            <div class="topNavName">KCOIN</div>
+        </a>
     </div>
     <div class="navigation">
         <img src="{{.user.Data.HeadShotUrl}}">


### PR DESCRIPTION
1. 本来首页的平台管理跳转到注资历史页面，现在修改为平台信息页面。
2. 在平台管理页面的topNav中加入了跳转回首页的Logo。